### PR TITLE
change order of testing and saving ckpt

### DIFF
--- a/thsolver/solver.py
+++ b/thsolver/solver.py
@@ -339,12 +339,12 @@ class Solver:
       # testing or not
       if epoch % self.FLAGS.SOLVER.test_every_epoch != 0:
         continue
-
-      # testing epoch
-      self.test_epoch(epoch)
-
+      
       # checkpoint
       self.save_checkpoint(epoch)
+      
+      # testing epoch
+      self.test_epoch(epoch)     
 
     # sync and exit
     if self.world_size > 1:


### PR DESCRIPTION
Change the order of performing test and saving checkpoint when the epoch reaches test interval, so that the checkpoint can be safely pre-saved if there exist problems or bugs in the testing process 